### PR TITLE
Fix warnings of inspect.getargspec, assertEquals, assertRaisesRegexp and async-coroutine

### DIFF
--- a/calleee/_compat.py
+++ b/calleee/_compat.py
@@ -72,6 +72,7 @@ del MetaclassDecorator
 
 def getargspec(obj):
     """Portable version of inspect.getargspec().
+    Since we dropped 2.7, this has to be deprecated.
 
     Necessary because the original is no longer available
     starting from Python 3.6.
@@ -81,10 +82,6 @@ def getargspec(obj):
     Note that distinction between positional-or-keyword and keyword-only
     parameters will be lost, as the original getargspec() doesn't honor it.
     """
-    try:
-        return inspect.getargspec(obj)
-    except AttributeError:
-        pass  # we let a TypeError through
 
     # translate the signature object back into the 4-tuple
     argnames = []

--- a/calleee/base.py
+++ b/calleee/base.py
@@ -158,9 +158,8 @@ class Matcher(BaseMatcher):
         # check if the matcher class has a parametrized constructor
         has_argful_ctor = False
         if '__init__' in self.__class__.__dict__:
-            argnames, vargargs, kwargs, _ = inspect.getargspec(
-                self.__class__.__init__)
-            has_argful_ctor = bool(argnames[1:] or vargargs or kwargs)
+            signature = inspect.signature(self.__class__.__init__)
+            has_argful_ctor = len(signature.parameters) > 1
 
         # if so, then it probably means it has some interesting state
         # in its attributes which we can include in the default representation

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -87,28 +87,28 @@ class Matcher(TestCase):
         """Test default __repr__ of Matcher subclass without a constructor."""
         class Custom(__unit__.Matcher):
             pass
-        self.assertEquals("<Custom>", "%r" % Custom())
+        self.assertEqual("<Custom>", "%r" % Custom())
 
     def test_repr__argless_ctor__no_state(self):
         """Test default __repr__ of Matcher subclass with argless ctor."""
         class Custom(__unit__.Matcher):
             def __init__(self):
                 pass
-        self.assertEquals("<Custom>", "%r" % Custom())
+        self.assertEqual("<Custom>", "%r" % Custom())
 
     def test_repr__argless_ctor__with_state(self):
         """Test __repr__ of Matcher subclass with argless ctor & state."""
         class Custom(__unit__.Matcher):
             def __init__(self):
                 self.foo = 42
-        self.assertEquals("<Custom>", "%r" % Custom())
+        self.assertEqual("<Custom>", "%r" % Custom())
 
     def test_repr__argful_ctor__no_state(self):
         """Test __repr__ with argful constructor but no actual fields."""
         class Custom(__unit__.Matcher):
             def __init__(self, unused):
                 pass
-        self.assertEquals("<Custom(...)>", "%r" % Custom('unused'))
+        self.assertEqual("<Custom(...)>", "%r" % Custom('unused'))
 
     def test_repr__argful_ctor__with_state_from_args(self):
         """Test __repr__ with argful constructor & object fields."""
@@ -117,7 +117,7 @@ class Matcher(TestCase):
                 self.foo = foo
 
         foo = 'bar'
-        self.assertEquals("<Custom(foo=%r)>" % (foo,),
+        self.assertEqual("<Custom(foo=%r)>" % (foo,),
                           "%r" % Custom(foo='bar'))
 
     def test_repr__argful_ctor__with_unrelated_state(self):
@@ -126,7 +126,7 @@ class Matcher(TestCase):
             def __init__(self, foo):
                 self.bar = 42
 
-        self.assertEquals("<Custom(bar=42)>", "%r" % Custom(foo='unused'))
+        self.assertEqual("<Custom(bar=42)>", "%r" % Custom(foo='unused'))
 
 
 class Eq(MatcherTestCase):
@@ -183,7 +183,7 @@ class LogicalCombinators(MatcherTestCase):
         not_no_digits = ~self.NoDigits()  # i.e. HasDigits
         has_digits = self.HasDigits()
         for s in test_strings:
-            self.assertEquals(
+            self.assertEqual(
                 has_digits.match(s), not_no_digits.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     has_digits, not_no_digits, s))
@@ -205,7 +205,7 @@ class LogicalCombinators(MatcherTestCase):
         all_digits_and_all_digits = self.AllDigits() & self.AllDigits()
         all_digits = self.AllDigits()
         for s in test_strings:
-            self.assertEquals(
+            self.assertEqual(
                 all_digits.match(s), all_digits_and_all_digits.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     all_digits, all_digits_and_all_digits, s))
@@ -215,7 +215,7 @@ class LogicalCombinators(MatcherTestCase):
         short_and_digits = self.Short() & self.AllDigits()
         short_digits = self.ShortDigits()
         for s in test_strings:
-            self.assertEquals(
+            self.assertEqual(
                 short_digits.match(s), short_and_digits.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     short_digits, short_and_digits, s))
@@ -237,7 +237,7 @@ class LogicalCombinators(MatcherTestCase):
         short_or_short = self.Short() | self.Short()
         short = self.Short()
         for s in test_strings:
-            self.assertEquals(
+            self.assertEqual(
                 short.match(s), short_or_short.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     short, short_or_short, s))
@@ -247,7 +247,7 @@ class LogicalCombinators(MatcherTestCase):
         has_digits_or_long = self.HasDigits() | self.Long()
         long_or_has_digits = self.LongOrHasDigits()
         for s in test_strings:
-            self.assertEquals(
+            self.assertEqual(
                 long_or_has_digits.match(s), has_digits_or_long.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     long_or_has_digits, has_digits_or_long, s))
@@ -279,7 +279,7 @@ class LogicalCombinators(MatcherTestCase):
         for s in test_strings:
             # Note that the truth of assertion is specific to those predicates:
             # the second one implies the first one.
-            self.assertEquals(
+            self.assertEqual(
                 only_some_digits.match(s), any_xor_all_digits.match(s),
                 msg="expected `%r` and `%r` to match %r equivalently" % (
                     only_some_digits, any_xor_all_digits, s))

--- a/tests/test_collections.py
+++ b/tests/test_collections.py
@@ -2,6 +2,7 @@
 Tests for collections' matchers.
 """
 import collections
+from collections import abc
 
 import calleee.collections as __unit__
 from tests import MatcherTestCase
@@ -170,12 +171,12 @@ class Set(MatcherTestCase):
 
 # Mappings
 
-class CustomDict(collections.MutableMapping):
+class CustomDict(abc.MutableMapping):
     """"Custom, no-op mapping class that just wraps a regular Python dict
     but is not a Python dict itself.
     """
     def __init__(self, iterable=(), **kwargs):
-        if isinstance(iterable, collections.Mapping):
+        if isinstance(iterable, abc.Mapping):
             iterable = iterable.items()
 
         self.d = {}

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -173,8 +173,7 @@ class CoroutineFunction(MatcherTestCase):
 
     @skipUnless(IS_PY34, "requires Python 3.4+")
     def test_coroutine__decorator(self):
-        @asyncio.coroutine
-        def coro_func(loop):
+        async def coro_func(loop):
             pass
         coro = self.await_(coro_func)
         self.assert_no_match(coro)
@@ -196,8 +195,7 @@ class CoroutineFunction(MatcherTestCase):
 
     @skipUnless(IS_PY34, "requires Python 3.4+")
     def test_coroutine_function__decorator(self):
-        @asyncio.coroutine
-        def coro_func(loop):
+        async def coro_func(loop):
             pass
         self.assert_match(coro_func)
 

--- a/tests/test_general.py
+++ b/tests/test_general.py
@@ -228,7 +228,7 @@ class Captor(MatcherTestCase):
 
     def test_ctor__invalid_matcher(self):
         not_matcher = object()
-        with self.assertRaisesRegexp(TypeError, r'expected'):
+        with self.assertRaisesRegex(TypeError, r'expected'):
             __unit__.Captor(not_matcher)
 
     def test_ctor__matcher(self):
@@ -238,7 +238,7 @@ class Captor(MatcherTestCase):
 
     def test_ctor__captor(self):
         captor = __unit__.Captor()
-        with self.assertRaisesRegexp(TypeError, r'captor'):
+        with self.assertRaisesRegex(TypeError, r'captor'):
             __unit__.Captor(captor)
 
     def test_has_value__initial(self):
@@ -258,14 +258,14 @@ class Captor(MatcherTestCase):
 
     def test_arg__initial(self):
         captor = __unit__.Captor()
-        with self.assertRaisesRegexp(ValueError, r'no value'):
+        with self.assertRaisesRegex(ValueError, r'no value'):
             captor.arg
 
     def test_arg__not_captured(self):
         # When the argument fails the matcher test, it should not be captured.
         captor = __unit__.Captor(self.FALSE_MATCHER)
         captor.match(self.ARG)
-        with self.assertRaisesRegexp(ValueError, r'no value'):
+        with self.assertRaisesRegex(ValueError, r'no value'):
             captor.arg
 
     def test_arg__captured(self):
@@ -284,7 +284,7 @@ class Captor(MatcherTestCase):
     def test_match__double_capture(self):
         captor = __unit__.Captor()
         captor.match(self.ARG)
-        with self.assertRaisesRegexp(ValueError, r'already'):
+        with self.assertRaisesRegex(ValueError, r'already'):
             captor.match(self.ARG)
 
     def test_repr__not_captured(self):

--- a/tests/test_objects.py
+++ b/tests/test_objects.py
@@ -77,8 +77,7 @@ class Coroutine(MatcherTestCase):
 
     @skipUnless(IS_PY34, "requires Python 3.4+")
     def test_coroutine__decorator(self):
-        @asyncio.coroutine
-        def coro_func(loop):
+        async def coro_func(loop):
             pass
         coro = self.await_(coro_func)
         self.assert_match(coro)
@@ -100,8 +99,7 @@ class Coroutine(MatcherTestCase):
 
     @skipUnless(IS_PY34, "requires Python 3.4+")
     def test_coroutine_function__decorator(self):
-        @asyncio.coroutine
-        def coro_func(loop):
+        async def coro_func(loop):
             pass
         self.assert_no_match(coro_func)
 
@@ -169,13 +167,13 @@ class FileLike(MatcherTestCase):
             __unit__.FileLike(read=None, write=None)
 
     def test_repr(self):
-        self.assertEquals("<FileLike (read)>",
+        self.assertEqual("<FileLike (read)>",
                           repr(__unit__.FileLike(read=True, write=None)))
-        self.assertEquals("<FileLike (read,write)>",
+        self.assertEqual("<FileLike (read,write)>",
                           repr(__unit__.FileLike(read=True, write=True)))
-        self.assertEquals("<FileLike (noread)>",
+        self.assertEqual("<FileLike (noread)>",
                           repr(__unit__.FileLike(read=False, write=None)))
-        self.assertEquals("<FileLike (noread,nowrite)>",
+        self.assertEqual("<FileLike (noread,nowrite)>",
                           repr(__unit__.FileLike(read=False, write=False)))
 
     # Assertion functions

--- a/tox.ini
+++ b/tox.ini
@@ -1,25 +1,14 @@
 [tox]
 minversion=1.8
-envlist=py27, py36, py37, py38, py39, pypy3, flake8
+envlist=py36, py37, py38, py39, pypy3, flake8
 skip_missing_interpreters=true
 
 [testenv]
 deps=-rrequirements-test.txt
 commands=py.test
 
-[testenv:py27]
-deps=
-    {[testenv]deps}
-    -rrequirements-test-py32.txt
-
-# # pypy3 is currently Python 3.2 so it needs the mock backport
-# [testenv:pypy3]
-# deps=
-#     {[testenv]deps}
-#     -rrequirements-test-py32.txt
-
 [testenv:flake8]
-basepython=python2.7
+basepython=python3.6
 deps=
     {[testenv]deps}
     flake8


### PR DESCRIPTION
Fix warnings to be compatible with future versions of Python.